### PR TITLE
support prior req.query parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = ({
         httpMethod: req.method,
         path: pathname,
         isBase64Encoded: false,
-        queryStringParameters: _query
+        queryStringParameters: typeof (req.query) === 'object' ? req.query : _query
       })
     }
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,9 @@ module.exports = ({
   return (req, res, url, opts) => {
     const onResponse = opts.onResponse
     const rewriteHeaders = opts.rewriteHeaders || headersNoOp
-    const { _query, pathname } = URL.parse(url, true)
+
+    const shouldParseQueryString = typeof (req.query) !== 'object'
+    const { _query, pathname } = URL.parse(url, shouldParseQueryString)
 
     const params = {
       ClientContext: clientContext,
@@ -30,7 +32,7 @@ module.exports = ({
         httpMethod: req.method,
         path: pathname,
         isBase64Encoded: false,
-        queryStringParameters: typeof (req.query) === 'object' ? req.query : _query
+        queryStringParameters: shouldParseQueryString ? _query : req.query
       })
     }
 

--- a/tests/proxy-mock.js
+++ b/tests/proxy-mock.js
@@ -1,14 +1,16 @@
 module.exports = (params, cb) => {
   const { Payload } = params
-  const { path, body, httpMethod } = JSON.parse(Payload)
+  const { path, body, httpMethod, queryStringParameters } = JSON.parse(Payload)
 
   switch (httpMethod + ' ' + path) {
     case 'GET /service/get': {
       cb(null, {
         Payload: JSON.stringify({
-          headers: {},
+          headers: {
+            'content-type': 'application/json'
+          },
           statusCode: 200,
-          body: 'Hello World!'
+          body: JSON.stringify(queryStringParameters)
         }),
         StatusCode: 200
       })

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -42,8 +42,11 @@ describe('Smoke Test Suite', () => {
 
   it('should 200 on GET to valid remote endpoint', async () => {
     await request(gHttpServer)
-      .get('/service/get')
+      .get('/service/get?foo=bar')
       .expect(200)
+      .then((res) => {
+        expect(res.body.foo).to.equal('bar')
+      })
   })
 
   it('should 200 on POST to valid remote endpoint', async () => {


### PR DESCRIPTION
Changes:
- Allow forwarding the `req.query` object if exists.